### PR TITLE
Public Beta Version 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Inferno Collection Vehicle Attachment 1.41 Beta
+# Inferno Collection Vehicle Attachment 1.5 Alpha
 #
 # Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Inferno Collection Vehicle Attachment 1.5 Alpha
+# Inferno Collection Vehicle Attachment 1.5 Beta
 #
 # Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
 #

--- a/Client/Main.cs
+++ b/Client/Main.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Inferno Collection Vehicle Attachment 1.41 Beta
+ * Inferno Collection Vehicle Attachment 1.5 Alpha
  * 
  * Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
  * 

--- a/Client/Main.cs
+++ b/Client/Main.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Inferno Collection Vehicle Attachment 1.5 Alpha
+ * Inferno Collection Vehicle Attachment 1.5 Beta
  * 
  * Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
  * 
@@ -68,7 +68,7 @@ namespace InfernoCollection.VehicleCollection.Client
                 throw new Exception("This resource requires at least OneSync \"legacy\". Use Public Beta Version 1.3 if you do not want to use OneSync.");
             }
 
-            TriggerEvent("chat:addSuggestion", "/attach [help|cancel]", "Starts the process of attaching one vehicle to another.");
+            TriggerEvent("chat:addSuggestion", "/attach [driveon|help|cancel]", "Starts the process of attaching one vehicle to another.");
             TriggerEvent("chat:addSuggestion", "/detach [help|cancel]", "Starts the process of detaching one vehicle from another.");
 
             #region Key Mapping

--- a/Client/Models/AttachmentStage.cs
+++ b/Client/Models/AttachmentStage.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Inferno Collection Vehicle Attachment 1.5 Alpha
+ * Inferno Collection Vehicle Attachment 1.5 Beta
  * 
  * Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
  * 

--- a/Client/Models/AttachmentStage.cs
+++ b/Client/Models/AttachmentStage.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Inferno Collection Vehicle Attachment 1.41 Beta
+ * Inferno Collection Vehicle Attachment 1.5 Alpha
  * 
  * Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
  * 

--- a/Client/Models/AttachmentStage.cs
+++ b/Client/Models/AttachmentStage.cs
@@ -19,6 +19,7 @@ namespace InfernoCollection.VehicleAttachment.Client.Models
         TowTruck,
         VehicleToBeTowed,
         Position,
+        DriveOn,
         Detach,
         Cancel
     }

--- a/Client/Models/Config.cs
+++ b/Client/Models/Config.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Inferno Collection Vehicle Attachment 1.5 Alpha
+ * Inferno Collection Vehicle Attachment 1.5 Beta
  * 
  * Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
  * 

--- a/Client/Models/Config.cs
+++ b/Client/Models/Config.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Inferno Collection Vehicle Attachment 1.41 Beta
+ * Inferno Collection Vehicle Attachment 1.5 Alpha
  * 
  * Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
  * 

--- a/Client/Models/TowedVehicle.cs
+++ b/Client/Models/TowedVehicle.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Inferno Collection Vehicle Attachment 1.5 Alpha
+ * Inferno Collection Vehicle Attachment 1.5 Beta
  * 
  * Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
  * 

--- a/Client/Models/TowedVehicle.cs
+++ b/Client/Models/TowedVehicle.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Inferno Collection Vehicle Attachment 1.41 Beta
+ * Inferno Collection Vehicle Attachment 1.5 Alpha
  * 
  * Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
  * 

--- a/Client/fxmanifest.lua
+++ b/Client/fxmanifest.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Vehicle Attachment 1.5 Alpha
+-- Inferno Collection Vehicle Attachment 1.5 Beta
 -- 
 -- Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
 -- 
@@ -15,7 +15,7 @@ description "A lightweight vehicle attachment/tow script for FiveM."
 
 author "Inferno Collection (inferno-collection.com)"
 
-version "1.5 Alpha"
+version "1.5 Beta"
 
 url "https://inferno-collection.com"
 

--- a/Client/fxmanifest.lua
+++ b/Client/fxmanifest.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Vehicle Attachment 1.41 Beta
+-- Inferno Collection Vehicle Attachment 1.5 Alpha
 -- 
 -- Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
 -- 
@@ -15,7 +15,7 @@ description "A lightweight vehicle attachment/tow script for FiveM."
 
 author "Inferno Collection (inferno-collection.com)"
 
-version "1.41 Beta"
+version "1.5 Alpha"
 
 url "https://inferno-collection.com"
 

--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,4 +1,4 @@
-Inferno Collection Vehicle Attachment 1.41 Beta
+Inferno Collection Vehicle Attachment 1.5 Alpha
 
 Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
 

--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,4 +1,4 @@
-Inferno Collection Vehicle Attachment 1.5 Alpha
+Inferno Collection Vehicle Attachment 1.5 Beta
 
 Copyright (c) 2019-2021, Christopher M, Inferno Collection. All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![top_image|2120x352](https://i.imgur.com/eydEeF0.jpg) 
 # Inferno Collection: Vehicle Attachment
-[![Build Status](https://travis-ci.com/inferno-collection/Vehicle-Attachment.svg?branch=master)](https://travis-ci.com/inferno-collection/Vehicle-Attachment)
+[![Build Status](https://travis-ci.com/inferno-collection/Vehicle-Attachment.svg?branch=feature/1.5-alpha)](https://travis-ci.com/inferno-collection/Vehicle-Attachment)
 
-__Public Beta Version 1.41__
+__Public Alpha Version 1.5__
 
 A lightweight vehicle attachment/tow script for FiveM. Attach vehicles to other vehicles and adjust the positioning with easy to use keybinds. Multiple attachments to the same vehicles (such as a flatbed trailer) are also possible.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![top_image|2120x352](https://i.imgur.com/eydEeF0.jpg) 
 # Inferno Collection: Vehicle Attachment
-[![Build Status](https://travis-ci.com/inferno-collection/Vehicle-Attachment.svg?branch=feature/1.5-alpha)](https://travis-ci.com/inferno-collection/Vehicle-Attachment)
+[![Build Status](https://travis-ci.com/inferno-collection/Vehicle-Attachment.svg?branch=master)](https://travis-ci.com/inferno-collection/Vehicle-Attachment)
 
-__Public Alpha Version 1.5__
+__Public Beta Version 1.5__
 
 A lightweight vehicle attachment/tow script for FiveM. Attach vehicles to other vehicles and adjust the positioning with easy to use keybinds. Multiple attachments to the same vehicles (such as a flatbed trailer) are also possible.
 
@@ -17,9 +17,10 @@ Presently, the following can be customized:
 - Max number of vehicles attached to one tow vehicle
 - Max distance from tow vehicles other vehicles can be attached.
 - Control over how fast/slow attachment positioning is.
+- Option to drive vehicles onto towing vehicle to confirm position (`/attach driveon`)
 
 Usage:
-- Go up to a vehicle and type `/attach`
+- Go up to a vehicle and type `/attach` or `/attach driveon`
 - Select the tow vehicle, and then vehicle to be towed with the `Enter` key
 - Follow on screen instructions to position the vehicle
 - Repeat for as many vehicles as you would like to attach


### PR DESCRIPTION
This resource requires at least OneSync "legacy". Use [Public Beta Version 1.3](https://github.com/inferno-collection/Vehicle-Attachment/releases/tag/v1.3-beta) if you do not want to use OneSync.

Added:
- `/attach driveon` which allows you to drive a vehicle that will be towed, onto your tow vehicle to confirm its position, attaching it exactly where you positioned it on the towing vehicle. The command toggles this mode on and off.